### PR TITLE
Add "go mod tidy" step to GitHub workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           go-version: '1.24'
 
+      - name: Run go mod tidy
+        run: go mod tidy
+
       - name: Cache Go Modules
         uses: actions/cache@v3
         with:

--- a/.github/workflows/run_unit_tests_on_master.yml
+++ b/.github/workflows/run_unit_tests_on_master.yml
@@ -18,6 +18,9 @@ jobs:
         with:
           go-version: '1.24'
 
+      - name: Run go mod tidy
+        run: go mod tidy
+
       - name: Cache Go Modules
         uses: actions/cache@v3
         with:

--- a/.github/workflows/run_unit_tests_on_pr.yml
+++ b/.github/workflows/run_unit_tests_on_pr.yml
@@ -17,6 +17,9 @@ jobs:
         with:
           go-version: '1.24'
 
+      - name: Run go mod tidy
+        run: go mod tidy
+
       - name: Cache Go Modules
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
This ensures Go module dependencies are cleaned up before caching, preventing potential issues with outdated or unused dependencies. Changes were applied to release, PR, and master workflows for consistency.