### PR TITLE
Update next-release-tag action to version 6.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,7 @@ jobs:
           tag_name: ${{ steps.generate_release_tag.outputs.next_release_tag }}
           release_name: ${{ steps.generate_release_tag.outputs.next_release_tag }}
           body: |
+            ## What's Changed
             ${{ steps.generate_changelog.outputs.changelog }}
           draft: false
           prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Generate release tag
         id: generate_release_tag
-        uses: amitsingh-007/next-release-tag@v4.1.0
+        uses: amitsingh-007/next-release-tag@v6.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tag_prefix: 'v'


### PR DESCRIPTION
Upgraded the next-release-tag action from v4.1.0 to v6.1.0 in the release workflow. This ensures compatibility with the latest features and bug fixes provided by the updated action version.