### PR TITLE
Add cleanup step and enforce master branch checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,13 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
 
+      - name: Checkout master branch
+        run: git checkout master
+
+      - name: Clean up existing files
+        run: |
+          rm -rf ../../../go/pkg/mod/*
+
       - name: Generate Changelog with Release Drafter
         uses: release-drafter/release-drafter@v5
         id: generate_changelog


### PR DESCRIPTION
Ensure the workflow cleans up Go module cache and switches to the master branch before generating the changelog. This prevents stale files from impacting the release process and guarantees consistency during execution.