### PR TITLE
Update Go module caching in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,12 +30,17 @@ jobs:
         with:
           go-version: '1.24'
 
+      - name: Clear Go mod cache
+        run: rm -rf ~/go/pkg/mod
+
+      - name: Show hashFiles key
+        run: echo "Cache key: v1-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ github.run_id }}"
+
       - name: Cache Go Modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/go-build
-            ~/go/pkg/mod
           key: v1-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ github.run_id }}
           restore-keys: |
             v1-${{ runner.os }}-go-


### PR DESCRIPTION
Switch to actions/cache@v4 and refine caching strategy for Go modules. Added steps to clear the Go mod cache and log the cache key for better debugging and consistency.