### PR TITLE
Update GitHub Actions to use actions/cache@v4 and refactor steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,18 +30,19 @@ jobs:
         with:
           go-version: '1.24'
 
+      - name: Run go mod tidy
+        run: go mod tidy
+
       - name: Cache Go Modules
         uses: actions/cache@v4
         with:
+          # Caching both module downloads and build cache
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
           key: v1-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ github.run_id }}
           restore-keys: |
             v1-${{ runner.os }}-go-
-
-      - name: Run go mod tidy
-        run: go mod tidy
 
       - name: Build Release Artifacts
         run: make release-all

--- a/.github/workflows/run_unit_tests_on_master.yml
+++ b/.github/workflows/run_unit_tests_on_master.yml
@@ -21,7 +21,7 @@ jobs:
         run: go mod tidy
 
       - name: Cache Go Modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           # Caching both module downloads and build cache
           path: |

--- a/.github/workflows/run_unit_tests_on_pr.yml
+++ b/.github/workflows/run_unit_tests_on_pr.yml
@@ -21,7 +21,7 @@ jobs:
         run: go mod tidy
 
       - name: Cache Go Modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           # Caching both module downloads and build cache
           path: |


### PR DESCRIPTION
Upgraded the cache action to `actions/cache@v4` in workflows for consistency and improvements. Reorganized steps in the release workflow by moving `go mod tidy` before caching to optimize execution. These changes improve workflow efficiency and maintain compatibility with the latest action versions.