### PR TITLE
```

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,6 @@ jobs:
         with:
           go-version: '1.24'
 
-      - name: Run go mod tidy
-        run: go mod tidy
-
       - name: Cache Go Modules
         uses: actions/cache@v4
         with:
@@ -43,6 +40,9 @@ jobs:
           key: v1-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ github.run_id }}
           restore-keys: |
             v1-${{ runner.os }}-go-
+
+      - name: Run go mod tidy
+        run: go mod tidy
 
       - name: Build Release Artifacts
         run: make release-all

--- a/.github/workflows/run_unit_tests_on_master.yml
+++ b/.github/workflows/run_unit_tests_on_master.yml
@@ -17,9 +17,6 @@ jobs:
         with:
           go-version: '1.24'
 
-      - name: Run go mod tidy
-        run: go mod tidy
-
       - name: Cache Go Modules
         uses: actions/cache@v4
         with:
@@ -30,6 +27,9 @@ jobs:
           key: v1-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ github.run_id }}
           restore-keys: |
             v1-${{ runner.os }}-go-
+
+      - name: Run go mod tidy
+        run: go mod tidy
 
       - name: Run Unit Tests
         run: go test -v ./...

--- a/.github/workflows/run_unit_tests_on_pr.yml
+++ b/.github/workflows/run_unit_tests_on_pr.yml
@@ -17,9 +17,6 @@ jobs:
         with:
           go-version: '1.24'
 
-      - name: Run go mod tidy
-        run: go mod tidy
-
       - name: Cache Go Modules
         uses: actions/cache@v4
         with:
@@ -30,6 +27,9 @@ jobs:
           key: v1-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ github.run_id }}
           restore-keys: |
             v1-${{ runner.os }}-go-
+
+      - name: Run go mod tidy
+        run: go mod tidy
 
       - name: Run Unit Tests
         run: go test -v ./...


### PR DESCRIPTION
Reorder "go mod tidy" step in GitHub workflows

Moved the "go mod tidy" step to occur after caching Go modules for better performance and to ensure dependencies are tidied after restoring the cache. This adjustment was applied consistently across all affected workflows.
```