### PR TITLE
Update workflows to use latest actions and optimize steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
         with:
           ref: master
 
@@ -26,23 +26,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set Up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5.4.0
         with:
           go-version: '1.24'
 
-      - name: Cache Go Modules
-        uses: actions/cache@v4
-        with:
-          # Caching both module downloads and build cache
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: v1-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ github.run_id }}
-          restore-keys: |
-            v1-${{ runner.os }}-go-
-
-      - name: Run go mod tidy
-        run: go mod tidy
+      - name: Go Version
+        run: go version
+        continue-on-error: true
 
       - name: Build Release Artifacts
         run: make release-all
@@ -78,24 +68,4 @@ jobs:
           prerelease: false
 
       - name: Upload Release Assets
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          upload_url="${{ steps.create_release.outputs.upload_url }}"
-          upload_url="${upload_url%\{*}"
-          for asset in *.tar.gz *.zip; do
-            if [ -f "$asset" ]; then
-              echo "Uploading $asset"
-              if [[ "$asset" == *.zip ]]; then
-                content_type="application/zip"
-              else
-                content_type="application/gzip"
-              fi
-              encoded_name=$(python3 -c "import urllib.parse; print(urllib.parse.quote('''$asset'''))")
-              curl --fail -X POST \
-                -H "Authorization: token $GITHUB_TOKEN" \
-                -H "Content-Type: ${content_type}" \
-                --data-binary @"$asset" \
-                "${upload_url}?name=${encoded_name}"
-            fi
-          done
+        run: gh release upload "${{ github.ref_name }}" *.tar.gz *.zip

--- a/.github/workflows/run_unit_tests_on_master.yml
+++ b/.github/workflows/run_unit_tests_on_master.yml
@@ -10,26 +10,16 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.2.2
 
       - name: Set Up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5.4.0
         with:
           go-version: '1.24'
 
-      - name: Cache Go Modules
-        uses: actions/cache@v4
-        with:
-          # Caching both module downloads and build cache
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: v1-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ github.run_id }}
-          restore-keys: |
-            v1-${{ runner.os }}-go-
-
-      - name: Run go mod tidy
-        run: go mod tidy
+      - name: Go Version
+        run: go version
+        continue-on-error: true
 
       - name: Run Unit Tests
-        run: go test -v ./...
+        run: go test -v -race -cover ./...

--- a/.github/workflows/run_unit_tests_on_pr.yml
+++ b/.github/workflows/run_unit_tests_on_pr.yml
@@ -10,26 +10,16 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.2.2
 
       - name: Set Up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5.4.0
         with:
           go-version: '1.24'
 
-      - name: Cache Go Modules
-        uses: actions/cache@v4
-        with:
-          # Caching both module downloads and build cache
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: v1-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ github.run_id }}
-          restore-keys: |
-            v1-${{ runner.os }}-go-
-
-      - name: Run go mod tidy
-        run: go mod tidy
+      - name: Go Version
+        run: go version
+        continue-on-error: true
 
       - name: Run Unit Tests
-        run: go test -v ./...
+        run: go test -v -race -cover ./...


### PR DESCRIPTION
Upgraded actions/checkout to v4.2.2 and actions/setup-go to v5.4.0 for all workflows. Removed caching and `go mod tidy` steps for simplification. Enhanced test command with race and coverage flags and updated release workflow to use `gh release upload` for uploading assets.