### PR TITLE
Update release workflow to remove explicit branch reference

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2
-        with:
-          ref: master
 
       - name: Generate Changelog with Release Drafter
         uses: release-drafter/release-drafter@v6.1.0


### PR DESCRIPTION
Removed the `ref: master` configuration from the checkout step to ensure compatibility with the default branch.