### PR TITLE
Set fetch-depth to 0 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0  # Fetch all branches
 
       - name: Generate Changelog with Release Drafter
         uses: release-drafter/release-drafter@v6.1.0


### PR DESCRIPTION
This ensures all branches are fetched during the checkout step, which is necessary for generating an accurate changelog. It prevents potential issues with missing commit history.