### PR TITLE
Add workflows for requiring and auto-applying PR labels

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,39 @@
+name: Auto Label Based on Branch Name
+
+permissions:
+  issues: write
+  pull-requests: read
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  auto-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = context.payload.pull_request.head.ref;
+            const prefix = branch.split('/')[0];
+            const label = prefix.toLowerCase();
+
+            const labels = await github.rest.issues.listLabelsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            const labelNames = labels.data.map(l => l.name.toLowerCase());
+
+            if (labelNames.includes(label)) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                labels: [label]
+              });
+              console.log(`Applied label: ${label}`);
+            } else {
+              console.log(`Label "${label}" not found in repo; skipping.`);
+            }

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,35 @@
+name: Auto Label Based on Branch Name
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  auto-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = context.payload.pull_request.head.ref;
+            const prefix = branch.split('/')[0];
+            const label = prefix.toLowerCase();
+
+            const labels = await github.rest.issues.listLabelsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            const labelNames = labels.data.map(l => l.name.toLowerCase());
+
+            if (labelNames.includes(label)) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                labels: [label]
+              });
+              console.log(`Applied label: ${label}`);
+            } else {
+              console.log(`Label "${label}" not found in repo; skipping.`);
+            }

--- a/.github/workflows/require_label.yml
+++ b/.github/workflows/require_label.yml
@@ -1,0 +1,27 @@
+name: Pull Request Labels
+on:
+  pull_request:
+    types: [opened, edited, labeled, unlabeled, synchronize]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: mheap/github-action-required-labels@v5
+        with:
+          mode: minimum
+          count: 1
+          labels: |
+            maintenance
+            bug
+            feature
+            enhancement
+            documentation
+          add_comment: true
+      - uses: mheap/github-action-required-labels@v5
+        with:
+          mode: exactly
+          count: 0
+          labels: "do not merge"

--- a/.github/workflows/require_label.yml
+++ b/.github/workflows/require_label.yml
@@ -1,0 +1,15 @@
+name: Require PR Label
+
+on:
+  pull_request:
+    types: [opened, edited, labeled, unlabeled, synchronize]
+
+jobs:
+  check-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pullreminders/label-checker@v1
+        with:
+          required-labels: "maintenance, bug, feature, dependencies, documentation"
+          enable-pr-label-check: true


### PR DESCRIPTION
Introduce two GitHub Actions workflows. The first enforces PRs to have specific labels: maintenance, bug, feature, dependencies, or documentation. The second automatically applies a label based on the branch name prefix if it matches existing labels in the repository.