### PR TITLE
Update permissions in auto-label workflow file

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,9 +1,9 @@
 name: Auto Label Based on Branch Name
 
 permissions:
-  contents: read
+  contents: write
   issues: write
-  pull-requests: write  # Changed from read to write
+  pull-requests: write
 
 on:
   pull_request:


### PR DESCRIPTION
Changed `contents` permission from read to write to ensure the workflow can modify repository content if needed. This aligns with the intended functionality of the workflow for proper operation.