### PR TITLE
Fix GitHub Actions token usage and clarify label check name

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Set up GitHub Script
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           script: |
             const branch = context.payload.pull_request.head.ref;
             const prefix = branch.split('/')[0];
@@ -43,8 +44,6 @@ jobs:
             } else {
               console.log(`Label "${label}" not found in repo; skipping.`);
             }
-        env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
       - name: Required Labels - Minimum
         uses: mheap/github-action-required-labels@v5
@@ -61,7 +60,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
-      - name: Required Labels - Exactly
+      - name: Required Labels - Do Not Merge
         uses: mheap/github-action-required-labels@v5
         with:
           mode: exactly


### PR DESCRIPTION
Replaced `env` token declaration with `with.github-token` due to a limit with fine-grained tokens. Renamed "Required Labels - Exactly" to "Required Labels - Do Not Merge" to improve clarity of its purpose.