### PR TITLE
Change CI Unit Tests Workflow

### DIFF
--- a/.github/workflows/run_all_unit_tests_on_master.yml
+++ b/.github/workflows/run_all_unit_tests_on_master.yml
@@ -1,0 +1,25 @@
+name: Run Unit Tests on Master
+
+on:
+  push:
+    branches: ["master"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+
+      - name: Set Up Go
+        uses: actions/setup-go@v5.4.0
+        with:
+          go-version: '1.24'
+
+      - name: Go Version
+        run: go version
+        continue-on-error: true
+
+      - name: Run Go Unit Tests
+        run: go test -v ./...

--- a/.github/workflows/run_go_unit_tests_on_pr.yml
+++ b/.github/workflows/run_go_unit_tests_on_pr.yml
@@ -1,8 +1,10 @@
-name: Run Unit Tests on PR
+name: Run Go Unit Tests on PR
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - '**/*.go'
 
 jobs:
   test:


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow to execute Go unit tests automatically on every push to the master branch. Additionally, a previously existing workflow has been modified to only run unit tests when Go files have changed, saving time and resources.